### PR TITLE
Expose Root TreeInfo node

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.1.10-alpha</Version>
+    <Version>0.1.11-alpha4</Version>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="SiteGen.Tests"></InternalsVisibleTo>

--- a/src/SiteGen.Core/Controllers/HomeController.cs
+++ b/src/SiteGen.Core/Controllers/HomeController.cs
@@ -77,7 +77,7 @@ public class HomeController : Controller
 
         node.Tree.Refresh(site);// nodes);
 
-        ViewBag.Root = site.First();
+        node.Tree.Root = site.First();
 
         // Process Markdown
         await processor.ProcessAsync(node, cancellationToken);

--- a/src/SiteGen.Core/Models/Hierarchy/TreeInfo.cs
+++ b/src/SiteGen.Core/Models/Hierarchy/TreeInfo.cs
@@ -149,6 +149,9 @@ public class TreeInfo<T> where T : class, ITreeEntity<T>, IEntity
             return default;
         }
     }
+
+    public SiteNode Root { get; internal set; }
+
     public void Refresh(IList<T> nodes)
     {
         siblings = nodes.Siblings(Entity, TreeListOptions.IncludeSelf).ToList();


### PR DESCRIPTION
Expose the `Root` node of the tree in the `TreeNode` class.

This is so we can get to the root of the tree from any node, and avoid having to use the `ViewBag` for storing the root of the tree.

This helps reduce boxing and keep our page models as strongly typed.